### PR TITLE
Feature/v0/settings

### DIFF
--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -1,7 +1,7 @@
 import {ThemedText} from "@/components/ThemedText";
-import {View} from "react-native";
 import {MedCards} from "@/app/(tabs)/home/meds-cards";
-import {useEffect, useState} from "react";
+import {useState} from "react";
+import {MainView} from "@/components/MainView";
 
 const array = [
     {
@@ -60,14 +60,9 @@ export default function Page() {
     const [meds, setMeds] = useState(array);
 
     return (
-        <View className="flex-1">
-
-            {/* Contenido */}
-            <View className="flex-1 flex-cols gap-4 p-5">
-                <ThemedText type={'title'}>Medicina para hoy:</ThemedText>
-                <MedCards MedCardsArray={meds}/>
-            </View>
-
-        </View>
+        <MainView className="flex-cols gap-4">
+            <ThemedText type={'title'}>Medicina para hoy:</ThemedText>
+            <MedCards MedCardsArray={meds}/>
+        </MainView>
     );
 }

--- a/app/(tabs)/home/meds-cards.tsx
+++ b/app/(tabs)/home/meds-cards.tsx
@@ -24,7 +24,7 @@ const StyledImage = cssInterop(Image, {
     className: 'style',
 })
 
-export function MedCard({ imageURI, med, dosage, nextDose }: SingleMedCardProps) {
+export function MedCard({imageURI, med, dosage, nextDose}: SingleMedCardProps) {
     const defaultImageURI = imageURI || 'https://static.vecteezy.com/system/resources/previews/005/259/960/non_2x/medicine-drugs-box-free-vector.jpg';
     const [checked, setChecked] = useState(false);
 
@@ -47,21 +47,17 @@ export function MedCard({ imageURI, med, dosage, nextDose }: SingleMedCardProps)
     );
 }
 
-export function MedCards({ MedCardsArray, className }: MedCardsProps) {
+export function MedCards({MedCardsArray, className}: MedCardsProps) {
     let index = 0;
 
     return (
         <FlatList
             className={cn(
                 'flex-1',
-                {
-                    'mb-[80]': Platform.OS !== 'ios',
-                    'mb-[20]': Platform.OS === 'ios',
-                },
                 className,
             )}
             data={MedCardsArray}
-            renderItem={({ item }) => (
+            renderItem={({item}) => (
                 <MedCard
                     imageURI={item.imageURI}
                     med={item.med}

--- a/app/(tabs)/settings/components.tsx
+++ b/app/(tabs)/settings/components.tsx
@@ -1,0 +1,35 @@
+import {Pressable, View} from "react-native";
+import {Image} from "expo-image";
+import {ThemedText} from "@/components/ThemedText";
+import {IconSymbol} from "@/components/ui/IconSymbol";
+import {cssInterop} from "nativewind";
+
+interface UserProps {
+    user: {
+        name: string;
+        email: string;
+        image: string;
+    }
+    logout?: () => void;
+}
+
+const StyledImage = cssInterop(Image, {
+    className: 'style',
+});
+
+export function UserSection({user, logout}: UserProps) {
+    return (
+        <View className={'flex-row items-center justify-between'}>
+            <View className={'flex-row items-center justify-between gap-4'}>
+                <StyledImage source={{uri: user.image}} className={'w-[60] h-[60] rounded-xl'}/>
+                <View>
+                    <ThemedText type={'subtitle'}>{user.name}</ThemedText>
+                    <ThemedText>{user.email}</ThemedText>
+                </View>
+            </View>
+            <Pressable onPress={logout}>
+                <IconSymbol name={'rectangle.portrait.and.arrow.right'} color={'#000'} size={36}/>
+            </Pressable>
+        </View>
+    );
+}

--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -1,18 +1,74 @@
-import {StyleSheet, View} from "react-native";
+import {Switch, View} from "react-native";
 import {ThemedText} from "@/components/ThemedText";
+import {MainView} from "@/components/MainView";
+import {useState} from "react";
+import {UserSection} from "@/app/(tabs)/settings/components";
+import {IconSymbol} from "@/components/ui/IconSymbol";
 
-export default function Page() {
-  return (
-      <View style={styles.container}>
-        <ThemedText>Settings Screen</ThemedText>
-      </View>
-  )
+const exampleUser = {
+    name: 'Juan Perez',
+    email: 'example@example.com',
+    image: 'https://freesvg.org/img/abstract-user-flat-4.png',
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  }
-});
+const testlogout = () => {
+    console.log('Logout');
+}
+
+export default function Page() {
+    const [user, setUser] = useState(exampleUser);
+    const [notificationsEnabled, setNotificationsEnabled] = useState(false);
+    const [alarmsEnabled, setAlarmsEnabled] = useState(false);
+
+    return (
+        <MainView className={'flex-col justify-between gap-4 p-4'}>
+
+            <View>
+                <View>
+                    <ThemedText type={'title'} className={'mb-2'}>Cuenta</ThemedText>
+                    <UserSection user={user} logout={testlogout}/>
+                </View>
+
+                <View>
+                    <ThemedText type={'title'} className={'mb-2'}>Notificaciones</ThemedText>
+
+                    <View className={'flex-row items-center justify-between'}>
+                        <ThemedText type={'subtitle'}>Notificaciones de actividad</ThemedText>
+                        <Switch
+                            value={notificationsEnabled}
+                            onValueChange={setNotificationsEnabled}
+                            trackColor={{false: '#767577', true: '#81b0ff'}}
+                            thumbColor={notificationsEnabled ? '#f5dd4b' : '#f4f3f4'}
+                            ios_backgroundColor="#3e3e3e"
+                        />
+                    </View>
+
+                    <View className={'flex-row items-center justify-between'}>
+                        <ThemedText type={'subtitle'}>Alarmas</ThemedText>
+                        <Switch
+                            value={alarmsEnabled}
+                            onValueChange={setAlarmsEnabled}
+                            trackColor={{false: '#767577', true: '#81b0ff'}}
+                            thumbColor={alarmsEnabled ? '#f5dd4b' : '#f4f3f4'}
+                            ios_backgroundColor="#3e3e3e"
+                        />
+                    </View>
+                </View>
+            </View>
+
+            <View className={'gap-2'}>
+                <View className={'flex-row items-center gap-2'}>
+                    <IconSymbol name={'questionmark.circle'} color={'black'} size={20}/>
+                    <ThemedText>Ayuda</ThemedText>
+                    <IconSymbol name={'chevron.right'} color={'black'} size={20}/>
+                </View>
+
+                <View className={'flex-row items-center gap-2'}>
+                    <IconSymbol name={'star.fill'} color={'black'} size={20}/>
+                    <ThemedText>Califícanos</ThemedText>
+                    <IconSymbol name={'chevron.right'} color={'black'} size={20}/>
+                </View>
+            </View>
+        </MainView>
+    )
+}

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -1,0 +1,20 @@
+import {Platform, View} from "react-native";
+import {cn} from "@/components/tailwind-merge";
+
+export function MainView({children, className}: {children: React.ReactNode, className?: string}) {
+    return (
+        <View
+            className={cn(
+                'flex-1 p-5',
+                {
+                    'mb-[80]': Platform.OS !== 'ios',
+                    'mb-[20]': Platform.OS === 'ios',
+                },
+                className,
+            )}
+        >
+            {children}
+        </View>
+    );
+
+}

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -21,6 +21,10 @@ const MAPPING = {
   'gear' : 'settings',
   'plus': 'add',
   'calendar': 'event',
+  'rectangle.portrait.and.arrow.right' : 'logout',
+  'questionmark.circle' : 'help',
+  'chevron.right' : 'chevron-right',
+  'star.fill' : 'star',
 } as IconMapping;
 
 /**


### PR DESCRIPTION
This pull request introduces significant updates to the tab navigation structure and functionality, as well as the addition of new screens and components for a React Native application. The changes include a refactor of the tab layout, removal of placeholder screens, and the implementation of new features such as a medicine tracking system, notes management, and user settings.

### Tab Navigation Updates:
* Refactored `app/(tabs)/_layout.tsx` to dynamically generate tabs from an array of configuration objects, simplifying the addition of new tabs. Updated tab styles and screen options, including a new background color and header visibility.

### Medicine Tracking:
* Added `app/(tabs)/home/index.tsx` to display a list of medicines for the day, using a new `MedCards` component to render individual medicine cards with details like dosage and next dose time.
* Created `app/(tabs)/home/meds-cards.tsx` to define the `MedCards` and `MedCard` components. These components use `FlatList` to render medicine cards with an image, dosage, and a checkbox for tracking doses.

### Notes Management:
* Added `app/(tabs)/notes/index.tsx` to display a list of notes and a floating "Add" button for creating new notes.
* Created `app/(tabs)/notes/NotesList.tsx` to render a list of notes using `FlatList`. Each note card displays a title, date, and time.
* Introduced `app/(tabs)/notes/AddButton.tsx` for a reusable floating button component styled for adding new notes.

### User Settings:
* Added `app/(tabs)/settings/index.tsx` to display user account details, notification toggles, and additional settings options like help and rating.
* Created `app/(tabs)/settings/components.tsx` to define the `UserSection` component for displaying user information and a logout button.

### Placeholder Screens:
* Added placeholder screens for `Medicine` (`app/(tabs)/medicine/index.tsx`), `Stats` (`app/(tabs)/stats/index.tsx`), and `Settings` (`app/(tabs)/settings/index.tsx`) with basic layouts and themed text. [[1]](diffhunk://#diff-b535a7b156d4855aee0b6a191fcda90de19f6ad41818129b75cc99595828267aR1-R18) [[2]](diffhunk://#diff-16d045801550807cacbb34e97b62b02676e8ac5e8608f696b66d43f039d639baR1-R18)